### PR TITLE
A simple Dockerfile that searches for the EICAR string in PCAP

### DIFF
--- a/runners/eicartest/Dockerfile
+++ b/runners/eicartest/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y \
+ python-scapy \
+ python-requests \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m tester
+USER tester
+
+COPY eicartest.py /home/tester/eicartest.py
+
+ENTRYPOINT ["python", "/home/tester/eicartest.py"]

--- a/runners/eicartest/eicartest.py
+++ b/runners/eicartest/eicartest.py
@@ -1,0 +1,39 @@
+import sys
+import json
+import requests
+import tempfile
+from scapy.all import *
+from scapy.error import Scapy_Exception
+
+if len(sys.argv) != 2:
+    print >>sys.stderr, "Usage: {} <url>".format(sys.argv[0])
+    sys.exit(1)
+
+try:
+    r = requests.get(sys.argv[1])
+    if r.status_code >= 400:
+        print json.dumps({"error": "File not found", "found": 0})
+        sys.exit(2)
+    with tempfile.NamedTemporaryFile() as temp:
+        temp.write(r.content)
+        temp.flush()
+        packets = rdpcap(temp.name)
+except requests.exceptions.RequestException as e:
+    print json.dumps({"error": "Requests error", "found": 0})
+    sys.exit(3)
+except Scapy_Exception:
+    print json.dumps({"error": "Scapy error", "found": 0})
+    sys.exit(4)
+
+EICAR = 'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+
+out = list()
+for packet in packets:
+    if EICAR in str(packet):
+        out.append(json.dumps({"found": 1, 
+                               "data": repr(packet.lastlayer().load)}))
+
+if not out:
+    out.append({"found": 0})
+
+print json.dumps(out)

--- a/runners/eicartest/eicartest.py
+++ b/runners/eicartest/eicartest.py
@@ -30,7 +30,7 @@ except (Scapy_Exception, NameError):
     print json.dumps({"meta": {"error": "Scapy error", "found": 0}})
     sys.exit(4)
 
-EICAR = 'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+EICAR = 'X5OWDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNU\nLUZJTEUhJEgrSCo='.decode('base64')
 
 found = 0
 

--- a/runners/eicartest/eicartest.py
+++ b/runners/eicartest/eicartest.py
@@ -2,7 +2,7 @@ import sys
 import json
 import requests
 import tempfile
-from scapy.all import *
+from scapy.all import rdpcap
 from scapy.error import Scapy_Exception
 
 if len(sys.argv) != 2:
@@ -12,28 +12,35 @@ if len(sys.argv) != 2:
 try:
     r = requests.get(sys.argv[1])
     if r.status_code >= 400:
-        print json.dumps({"error": "File not found", "found": 0})
+        print json.dumps(
+            {"meta":
+             {"error":
+              "File not retrieved (status code {})".format(r.status_code),
+              "found": 0}
+             })
         sys.exit(2)
     with tempfile.NamedTemporaryFile() as temp:
         temp.write(r.content)
         temp.flush()
         packets = rdpcap(temp.name)
 except requests.exceptions.RequestException as e:
-    print json.dumps({"error": "Requests error", "found": 0})
+    print json.dumps({"meta": {"error": "Requests error", "found": 0}})
     sys.exit(3)
-except Scapy_Exception:
-    print json.dumps({"error": "Scapy error", "found": 0})
+except (Scapy_Exception, NameError):
+    print json.dumps({"meta": {"error": "Scapy error", "found": 0}})
     sys.exit(4)
 
 EICAR = 'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
 
-out = list()
+found = 0
+
+meta = dict()
+data = list()
 for packet in packets:
     if EICAR in str(packet):
-        out.append(json.dumps({"found": 1, 
-                               "data": repr(packet.lastlayer().load)}))
+        found += 1
+        data.append({"payload": repr(str(packet)), "time": packet.time})
 
-if not out:
-    out.append({"found": 0})
+meta["found"] = found
 
-print json.dumps(out)
+print json.dumps({'meta': meta, 'data': data})


### PR DESCRIPTION
String search implemented with Scapy to parse PCAP files

EICAR is the EICAR anti-malware testfile as specified in:
http://www.eicar.org/86-0-Intended-use.html

The Dockerfile expects an URL to a PCAP file as the input.
